### PR TITLE
[TEST PR] add a debug print to the driver

### DIFF
--- a/kani-driver/src/call_goto_cc.rs
+++ b/kani-driver/src/call_goto_cc.rs
@@ -39,6 +39,7 @@ impl KaniSession {
         output: &Path,
         function: &str,
     ) -> Result<()> {
+        println!("useless debug print in call_goto_cc.rs");
         let mut cmd = Command::new("goto-cc");
         cmd.arg(input).args(["--function", function, "-o"]).arg(output);
 


### PR DESCRIPTION
Since only the driver has changed, end-to-end tests should run, while compiler tests should be skipped.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 and MIT licenses.
